### PR TITLE
Typo fix.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,6 @@
+v.1.1.2
+- Fix: Typo in CSS loading code caused a spurious browser warning such as "The script...was loaded even though its MIME type (“text/jsavascript”) is not a valid JavaScript MIME type.".
+
 v.1.1.1
 - Fix: HTTP 500 happened when the page includes the CSS that comes from CDN.
 

--- a/Toolbelt.AspNetCore.CssLiveReloader/Internals/CssLiveReloaderScriptHandler.cs
+++ b/Toolbelt.AspNetCore.CssLiveReloader/Internals/CssLiveReloaderScriptHandler.cs
@@ -14,7 +14,7 @@ namespace Toolbelt.AspNetCore.CssLiveReloader.Internals
                 "Toolbelt.AspNetCore.CssLiveReloader.script.min.js";
 #endif
             using var resStream = typeof(CssLiveReloaderScriptHandler).Assembly.GetManifestResourceStream(resourceName);
-            context.Response.ContentType = "text/jsavascript";
+            context.Response.ContentType = "text/javascript";
             await resStream.CopyToAsync(context.Response.Body);
         }
     }


### PR DESCRIPTION
Used to give a spurious browser warning such as "The script...was loaded even though its MIME type (“text/jsavascript”) is not a valid JavaScript MIME type.".